### PR TITLE
Publish site

### DIFF
--- a/Theme.php
+++ b/Theme.php
@@ -2704,6 +2704,11 @@ class Theme extends BaseV1\Theme
             'available_for_opportunities' => true,
         ]);
 
+        $this->registerOpportunityMetadata('publish_site', [
+            'type' => 'text',
+            'label' => \MapasCulturais\i::__('Publicar no site')
+        ]);
+
         //GERANDO NOVAS TAXONOMIA DE FUNCAO - NECESSÁRIO PARA V5.6.20
         $newsTaxo = array(
             i::__("Aderecista"),

--- a/Theme.php
+++ b/Theme.php
@@ -2362,6 +2362,7 @@ class Theme extends BaseV1\Theme
 
         /**
          * Hook para criar um metadata da Oportunidade com registro de publicação no site
+         * @params Object Request
          */
         $app->hook('POST(opportunity.publish_site)', function () use ($app) {
                 //Recebendo id da oportunidade, instanciando OpportunityMeta e inserindo o metadata

--- a/Theme.php
+++ b/Theme.php
@@ -3,6 +3,7 @@
 namespace Ceara;
 
 
+use MapasCulturais\Entities\OpportunityMeta;
 use \MapasCulturais\i;
 use MapasCulturais\App;
 use MapasCulturais\Utils;
@@ -2352,10 +2353,35 @@ class Theme extends BaseV1\Theme
             unset($properties_validations['shortDescription']['v::stringType()->length(0,400)']);
             $properties_validations['shortDescription']['v::stringType()->length(0,900)'] = 'A descrição curta deve ter no máximo 900 caracteres';
         });
+
+        $app->hook('template(opportunity.single.header-inscritos):actions', function () use ($app) {
+            if ($app->user->is('superAdmin')) {
+                $this->part('opportunity/btn-publish-site');
+            }
+        });
+
+        /**
+         * Hook para criar um metadata da Oportunidade com registro de publicação no site
+         */
+        $app->hook('POST(opportunity.publish_site)', function () use ($app) {
+                //Recebendo id da oportunidade, instanciando OpportunityMeta e inserindo o metadata
+                $op = $app->repo('Opportunity')->find($this->data['id']);
+                $newOpMeta = new OpportunityMeta;
+                $newOpMeta->owner = $op;
+                $newOpMeta->key = 'publish_site';
+                $newOpMeta->value = $this->postData['publish_site'];
+                $error = $newOpMeta->save(true);
+
+                if($error !== null){
+                    $this->errorJson(false, 400);
+                }
+                $this->json(['message' => 'Publicação realizada com sucesso', 'status' => 200],200);
+
+        });
      }
 
     /**
-     * Mesmo métido da Entidade User.php, mas com uma validação para tratar o erro
+     * Mesmo método da Entidade User.php, mas com uma validação para tratar o erro
      * em caso de uma inscrição excluída
      *
      * @return void
@@ -2676,6 +2702,7 @@ class Theme extends BaseV1\Theme
              ),
             'available_for_opportunities' => true,
         ]);
+
         //GERANDO NOVAS TAXONOMIA DE FUNCAO - NECESSÁRIO PARA V5.6.20
         $newsTaxo = array(
             i::__("Aderecista"),

--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -6895,4 +6895,7 @@ button.mfp-arrow-left {
   #sidebars {
     flex-direction: column; } }
 
+.mr-5 {
+  margin-right: 45px;
+}
 /*# sourceMappingURL=main.css.map */

--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -6895,6 +6895,7 @@ button.mfp-arrow-left {
   #sidebars {
     flex-direction: column; } }
 
+/*Publicar site de editais*/
 .mr-5 {
   margin-right: 45px;
 }

--- a/assets/js/opportunity-ceara/btn-disable-on-register.js
+++ b/assets/js/opportunity-ceara/btn-disable-on-register.js
@@ -1,13 +1,13 @@
 $( document ).ready(function() {
-    const btnRegister = document.querySelector("#opportunity-registration a.btn")
-
-    btnRegister.addEventListener('click', e => {
-        const inputAgent = document.querySelector('#select-registration-owner-button').innerText
-
-        if(inputAgent !== 'Agente responsável pela inscrição') {
-            e.target.setAttribute('style','cursor: not-allowed;pointer-events: none;background:#fff')
-            e.target.innerHTML = `<img src="${MapasCulturais.spinnerURL}" />`
-        }
-    })
+    // const btnRegister = document.querySelector("#opportunity-registration a.btn")
+    //
+    // btnRegister.addEventListener('click', e => {
+    //     const inputAgent = document.querySelector('#select-registration-owner-button').innerText
+    //
+    //     if(inputAgent !== 'Agente responsável pela inscrição') {
+    //         e.target.setAttribute('style','cursor: not-allowed;pointer-events: none;background:#fff')
+    //         e.target.innerHTML = `<img src="${MapasCulturais.spinnerURL}" />`
+    //     }
+    // })
 });
 

--- a/assets/js/opportunity-ceara/btn-disable-on-register.js
+++ b/assets/js/opportunity-ceara/btn-disable-on-register.js
@@ -1,13 +1,13 @@
 $( document ).ready(function() {
-    // const btnRegister = document.querySelector("#opportunity-registration a.btn")
-    //
-    // btnRegister.addEventListener('click', e => {
-    //     const inputAgent = document.querySelector('#select-registration-owner-button').innerText
-    //
-    //     if(inputAgent !== 'Agente responsável pela inscrição') {
-    //         e.target.setAttribute('style','cursor: not-allowed;pointer-events: none;background:#fff')
-    //         e.target.innerHTML = `<img src="${MapasCulturais.spinnerURL}" />`
-    //     }
-    // })
+    const btnRegister = document.querySelector("#opportunity-registration a.btn")
+
+    btnRegister.addEventListener('click', e => {
+        const inputAgent = document.querySelector('#select-registration-owner-button').innerText
+
+        if(inputAgent !== 'Agente responsável pela inscrição') {
+            e.target.setAttribute('style','cursor: not-allowed;pointer-events: none;background:#fff')
+            e.target.innerHTML = `<img src="${MapasCulturais.spinnerURL}" />`
+        }
+    })
 });
 

--- a/layouts/parts/opportunity/btn-publish-site.php
+++ b/layouts/parts/opportunity/btn-publish-site.php
@@ -1,0 +1,57 @@
+<?php
+?>
+<div style="width: 100%; display: block">
+    <hr>
+    <div style="width: 100%; display: block">
+        <h3 for="">Site Editais</h3>
+        <button type="button" class="btn btn-primary"
+                title="Publicar somente no site de editais"
+                id="btn-publish-site" onclick="confirmPublishSite()">
+            Publicar no site
+        </button>
+        <hr>
+        <br>
+    </div>
+
+</div>
+
+<script>
+    function confirmPublishSite() {
+        const swalWithBootstrapButtons = Swal.mixin({
+            customClass: {
+                confirmButton: "btn btn-success mr-5",
+                cancelButton: "btn btn-warning"
+            },
+            buttonsStyling: false
+        });
+        swalWithBootstrapButtons.fire({
+            title: "Publicar no site?",
+            text: "Ao confirmar, você publicará esse edital como encerrado no site de Editais, confirma essa ação?",
+            showCancelButton: true,
+            confirmButtonText: "Sim, publicar",
+            cancelButtonText: "Não, desistir"
+        }).then((result) => {
+            if (result.isConfirmed) {
+                $.ajax({
+                    method: "POST",
+                    url: MapasCulturais.createUrl('opportunity','publish_site',  [MapasCulturais.entity.id]),
+                    data: { publish_site: 'Sim'},
+                    success: function (data, status ){
+                        swalWithBootstrapButtons.fire({
+                            title: 'Sucesso!',
+                            text: data.message
+                        });
+                        setTimeout(() => {
+                            window.location.reload();
+                        }, 2000);
+                    }
+                })
+            } else if (
+                /* Read more about handling dismissals below */
+                result.dismiss === Swal.DismissReason.cancel
+            ) {
+              console.log('')
+            }
+        });
+    }
+</script>

--- a/layouts/parts/opportunity/btn-publish-site.php
+++ b/layouts/parts/opportunity/btn-publish-site.php
@@ -16,6 +16,7 @@
 </div>
 
 <script>
+    //Remover esse codigo script para arquivo .js
     function confirmPublishSite() {
         const swalWithBootstrapButtons = Swal.mixin({
             customClass: {


### PR DESCRIPTION
### CONTEXTO
Os editais da Secult/Ce precisam mostrar os editais que estão com o fluxo interno com publicação de resultado, ser mostrado o próprio edital que está com esse fluxo no site.
Mas como por algum motivo não existe a publicação de resultados para ter esse entendimento, então deve ter um botão para realizar essa ação de entender o edital encerrado.

### SOLUÇÃO
Criado um botão com um registro de metadados em oportunidade que especifica que o edital está pronto para publicação no site de editais.
