### PR TITLE
Corrigido filtro de avaliações pendentes.

### DIFF
--- a/Controllers/Opportunity.php
+++ b/Controllers/Opportunity.php
@@ -811,8 +811,8 @@ class Opportunity extends EntityController {
         $sql_status = "";
         if (isset($this->data['status'])) {
             if(preg_match('#EQ\( *(-?\d) *\)#', $this->data['status'], $matches)) {
-                $status = $matches[1];
-                $sql_status = " AND evaluation_status = {$status}";
+                $status = $matches[1] == -1 ? "IS NULL" : "= {$matches[1]}";
+                $sql_status = " AND evaluation_status {$status}";
             }
         }
 


### PR DESCRIPTION
## Corrigido filtro de avaliações pendentes.

De forma paliativa, adicionada verificação no controller Opportunity para caso seja recebido filtro `status=EQ(-1)` na query da view `evaluations` por `NULL`, pois não existe avaliação antes do avaliador acessar a primeira vez e portanto não existe status de pendência.